### PR TITLE
Update dependencies

### DIFF
--- a/Zstandard.Net.Benchmark/DontForceGcCollectionsConfig.cs
+++ b/Zstandard.Net.Benchmark/DontForceGcCollectionsConfig.cs
@@ -8,7 +8,7 @@ namespace Zstandard.Net.Benchmark
         public DontForceGcCollectionsConfig()
         {
             // tell BenchmarkDotNet not to force GC collections after every iteration
-            Add(Job.Default.With(new GcMode() { Force = false }));
+            AddJob(Job.Default.WithGcMode(new GcMode() { Force = false }));
         }
     }
 }

--- a/Zstandard.Net.Benchmark/Zstandard.Net.Benchmark.csproj
+++ b/Zstandard.Net.Benchmark/Zstandard.Net.Benchmark.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Zstandard.Net.Tests/Zstandard.Net.Tests.csproj
+++ b/Zstandard.Net.Tests/Zstandard.Net.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +10,16 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  <ItemGroup>  
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net45'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Zstandard.Net/Zstandard.Net.csproj
+++ b/Zstandard.Net/Zstandard.Net.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
   
 	<ItemGroup>
-	  <PackageReference Include="System.Buffers" Version="4.5.0" />
+	  <PackageReference Include="System.Buffers" Version="4.5.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Lib:
Update System.Buffers to 4.5.1

Test project:
Update to MSTest v2.1.2.
Add netcoreapp2.1 as a target framework. Used for running against the latest Microsoft.NET.Test.Sdk.
Add conditional version of Microsoft.NET.Test.Sdk v16.2.0 for netcoreapp2.0 testing.

Benchmark:
Update BenchmarkDotNet to v0.12.1
Update DontForceGcCollectionsConfig with new method names.
